### PR TITLE
Solve issue #1 (TypeError: 'NoneType' object is not callable)

### DIFF
--- a/NS_Forest_v2.ipynb
+++ b/NS_Forest_v2.ipynb
@@ -236,7 +236,7 @@
     "#Report generation and cleanup         \n",
     "        \n",
     "f1_store_1D_df = pd.DataFrame() #F1 store gives all results.\n",
-    "f1_store_1D_df = pd.DataFrame.from_dict(f1_store_1D, orient='index', dtype=str)\n",
+    "f1_store_1D_df = pd.DataFrame.from_dict(f1_store_1D, orient='index')\n",
     "f1_store_1D_df.columns = [\"f-measure\"]\n",
     "f1_store_1D_df['markerCount'] = f1_store_1D_df.index.str.count('&')\n",
     "f1_store_1D_df.reset_index(level=f1_store_1D_df.index.names, inplace=True)\n",


### PR DESCRIPTION
A tiny change to solve the issue described in #1:
I replaced the line 
```python
f1_store_1D_df = pd.DataFrame.from_dict(f1_store_1D, orient='index', dtype=str)
```
with
```python
f1_store_1D_df = pd.DataFrame.from_dict(f1_store_1D, orient='index')
```
It avoids casting `f-measure` to str, so that the 50 highest f-measures for each cluster can be properly identified. Otherwise, the script crashes before producing the final output NSForest_v2_topResults.csv.